### PR TITLE
Fix bug where order of loading of events was out of order

### DIFF
--- a/packages/cfpb-analytics/src/cfpb-analytics.js
+++ b/packages/cfpb-analytics/src/cfpb-analytics.js
@@ -17,10 +17,13 @@ function analyticsLog(...msg) {
 
 let loadTryCount = 0;
 
+/**
+ * @returns {boolean} Whether GTM has been loaded or not.
+ */
 function _isGtmLoaded() {
   window.dataLayer = window.dataLayer || [];
-  let gtmStartedEvent = window.dataLayer.find(
-    (element) => element['gtm.start']
+  const gtmStartedEvent = window.dataLayer.find(
+    (element) => element['gtm.start'],
   );
 
   if (!gtmStartedEvent) {
@@ -44,8 +47,8 @@ function _isGtmLoaded() {
 function ensureGoogleTagManagerLoaded() {
   return new Promise(function (resolve, reject) {
     (function waitForGoogleTagManager() {
-      if (++loadTryCount > 9) return reject();
       if (_isGtmLoaded()) return resolve();
+      if (++loadTryCount > 9) return reject();
       setTimeout(waitForGoogleTagManager, 500);
     })();
   });

--- a/packages/cfpb-analytics/src/cfpb-analytics.spec.js
+++ b/packages/cfpb-analytics/src/cfpb-analytics.spec.js
@@ -41,7 +41,7 @@ describe('cfpb-analytics', () => {
 
       window.dataLayer.push({
         'gtm.start': true,
-        'gtm.uniqueEventId': true
+        'gtm.uniqueEventId': true,
       });
       await analyticsSendEvent(payload);
       expect(window.dataLayer.length).toEqual(2);
@@ -68,7 +68,7 @@ describe('cfpb-analytics', () => {
       const callbackSpy = jest.spyOn(payload, 'eventCallback');
       window.dataLayer.push({
         'gtm.start': true,
-        'gtm.uniqueEventId': true
+        'gtm.uniqueEventId': true,
       });
       await analyticsSendEvent(payload);
       expect(callbackSpy).toHaveBeenCalledTimes(1);
@@ -94,15 +94,15 @@ describe('cfpb-analytics', () => {
       };
       const callbackSpy = jest.spyOn(payload, 'eventCallback');
       delete window['dataLayer'];
-      analyticsSendEvent(payload).then( async () =>{
+      analyticsSendEvent(payload).then(async () => {
         window['dataLayer'] = [];
         window.dataLayer.push({
           'gtm.start': true,
-          'gtm.uniqueEventId': true
+          'gtm.uniqueEventId': true,
         });
         await analyticsSendEvent(payload);
         expect(callbackSpy).toHaveBeenCalledTimes(1);
-      } );
+      });
     });
   });
 });


### PR DESCRIPTION
We were checking whether gtmLoaded second in the Promise. This should happen first, otherwise it'll reject after 9 calls.